### PR TITLE
Remove trailing whitespace after codeblock

### DIFF
--- a/forge-docs-book/src/building-models/constraints/instances.md
+++ b/forge-docs-book/src/building-models/constraints/instances.md
@@ -16,7 +16,7 @@ The remainder of this page defines instances more formally.
 
 ```admonish warning
 If you are working in Froglet, the remainder of this page may reference terms you are as yet unfamiliar with. Don't worry; this will be covered more in class. Informally, you might read "relation" as "function".
-``` 
+```
 
 ## Formal Definition of Instances
 


### PR DESCRIPTION
The warning code block in constraints/instances has a trailing whitespace, causing the MD to parse incorrectly and the html to display incorrectly. 
See here: [constraints/instances](https://csci1710.github.io/forge-documentation/building-models/constraints/instances.html).
I just removed the whitespace so it now renders as intended.